### PR TITLE
Add API key persistence

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -8,6 +8,7 @@ import { useMessageParser, usePromptEnhancer, useShortcuts, useSnapScroll } from
 import { useChatHistory } from '~/lib/persistence';
 import { chatStore } from '~/lib/stores/chat';
 import { workbenchStore } from '~/lib/stores/workbench';
+import { apiKeysStore } from '~/lib/stores/apiKeys';
 import { fileModificationsToHTML } from '~/utils/diff';
 import { cubicEasingFn } from '~/utils/easings';
 import { createScopedLogger, renderLogger } from '~/utils/logger';
@@ -72,11 +73,13 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
   const [chatStarted, setChatStarted] = useState(initialMessages.length > 0);
 
   const { showChat } = useStore(chatStore);
+  const { anthropic } = useStore(apiKeysStore);
 
   const [animationScope, animate] = useAnimate();
 
   const { messages, isLoading, input, handleInputChange, setInput, stop, append } = useChat({
     api: '/api/chat',
+    headers: anthropic ? { 'x-anthropic-api-key': anthropic } : undefined,
     onError: (error) => {
       logger.error('Request failed\n\n', error);
       toast.error('There was an error processing your request');

--- a/app/components/sidebar/ApiKeysDialog.client.tsx
+++ b/app/components/sidebar/ApiKeysDialog.client.tsx
@@ -1,0 +1,67 @@
+import { useStore } from '@nanostores/react';
+import { useState } from 'react';
+import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from '~/components/ui/Dialog';
+import { apiKeysStore } from '~/lib/stores/apiKeys';
+
+interface ApiKeysDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ApiKeysDialog({ open, onClose }: ApiKeysDialogProps) {
+  const keys = useStore(apiKeysStore);
+  const [openai, setOpenai] = useState(keys.openai || '');
+  const [google, setGoogle] = useState(keys.google || '');
+  const [anthropic, setAnthropic] = useState(keys.anthropic || '');
+
+  const save = () => {
+    apiKeysStore.set({ openai, google, anthropic });
+    onClose();
+  };
+
+  return (
+    <DialogRoot open={open}>
+      <Dialog onBackdrop={onClose} onClose={onClose}>
+        <DialogTitle>API Keys</DialogTitle>
+        <DialogDescription asChild>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              save();
+            }}
+            className="space-y-3"
+          >
+            <label className="flex flex-col">
+              <span className="mb-1">OpenAI</span>
+              <input
+                value={openai}
+                onChange={(e) => setOpenai(e.target.value)}
+                className="border rounded px-2 py-1 bg-bolt-elements-background-depth-1"
+              />
+            </label>
+            <label className="flex flex-col">
+              <span className="mb-1">Google</span>
+              <input
+                value={google}
+                onChange={(e) => setGoogle(e.target.value)}
+                className="border rounded px-2 py-1 bg-bolt-elements-background-depth-1"
+              />
+            </label>
+            <label className="flex flex-col">
+              <span className="mb-1">Anthropic</span>
+              <input
+                value={anthropic}
+                onChange={(e) => setAnthropic(e.target.value)}
+                className="border rounded px-2 py-1 bg-bolt-elements-background-depth-1"
+              />
+            </label>
+            <div className="flex justify-end gap-2 pt-2">
+              <DialogButton type="secondary" onClick={onClose}>Cancel</DialogButton>
+              <DialogButton type="primary" onClick={save}>Save</DialogButton>
+            </div>
+          </form>
+        </DialogDescription>
+      </Dialog>
+    </DialogRoot>
+  );
+}

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from
 import { IconButton } from '~/components/ui/IconButton';
 import { ThemeSwitch } from '~/components/ui/ThemeSwitch';
 import { db, deleteById, getAll, chatId, type ChatHistoryItem } from '~/lib/persistence';
+import { ApiKeysDialog } from './ApiKeysDialog.client';
 import { cubicEasingFn } from '~/utils/easings';
 import { logger } from '~/utils/logger';
 import { HistoryItem } from './HistoryItem';
@@ -38,6 +39,7 @@ export function Menu() {
   const [list, setList] = useState<ChatHistoryItem[]>([]);
   const [open, setOpen] = useState(false);
   const [dialogContent, setDialogContent] = useState<DialogContent>(null);
+  const [apiDialogOpen, setApiDialogOpen] = useState(false);
 
   const loadEntries = useCallback(() => {
     if (db) {
@@ -163,9 +165,16 @@ export function Menu() {
             </Dialog>
           </DialogRoot>
         </div>
-        <div className="flex items-center border-t border-bolt-elements-borderColor p-4">
+        <div className="flex items-center border-t border-bolt-elements-borderColor p-4 gap-2">
+          <button
+            className="text-bolt-elements-sidebar-buttonText hover:underline"
+            onClick={() => setApiDialogOpen(true)}
+          >
+            Manage API Keys
+          </button>
           <ThemeSwitch className="ml-auto" />
         </div>
+        <ApiKeysDialog open={apiDialogOpen} onClose={() => setApiDialogOpen(false)} />
       </div>
     </motion.div>
   );

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -21,9 +21,14 @@ export type Messages = Message[];
 
 export type StreamingOptions = Omit<Parameters<typeof _streamText>[0], 'model'>;
 
-export function streamText(messages: Messages, env: Env, options?: StreamingOptions) {
+export function streamText(
+  messages: Messages,
+  env: Env,
+  apiKey?: string,
+  options?: StreamingOptions,
+) {
   return _streamText({
-    model: getAnthropicModel(getAPIKey(env)),
+    model: getAnthropicModel(apiKey ?? getAPIKey(env)),
     system: getSystemPrompt(),
     maxTokens: MAX_TOKENS,
     headers: {

--- a/app/lib/stores/apiKeys.ts
+++ b/app/lib/stores/apiKeys.ts
@@ -1,0 +1,27 @@
+import { map } from 'nanostores';
+
+export interface ApiKeys {
+  openai?: string;
+  google?: string;
+  anthropic?: string;
+}
+
+const STORAGE_KEY = 'bolt_api_keys';
+
+function loadKeys(): ApiKeys {
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {}
+  return {};
+}
+
+export const apiKeysStore = map<ApiKeys>(loadKeys());
+
+apiKeysStore.subscribe((value) => {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+});

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -14,6 +14,9 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
   const stream = new SwitchableStream();
 
   try {
+    const anthropicApiKey =
+      request.headers.get('x-anthropic-api-key') || context.cloudflare.env.ANTHROPIC_API_KEY;
+
     const options: StreamingOptions = {
       toolChoice: 'none',
       onFinish: async ({ text: content, finishReason }) => {
@@ -32,13 +35,13 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
         messages.push({ role: 'assistant', content });
         messages.push({ role: 'user', content: CONTINUE_PROMPT });
 
-        const result = await streamText(messages, context.cloudflare.env, options);
+        const result = await streamText(messages, context.cloudflare.env, anthropicApiKey, options);
 
         return stream.switchSource(result.toAIStream());
       },
     };
 
-    const result = await streamText(messages, context.cloudflare.env, options);
+    const result = await streamText(messages, context.cloudflare.env, anthropicApiKey, options);
 
     stream.switchSource(result.toAIStream());
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1,3 +1,5 @@
 interface Env {
   ANTHROPIC_API_KEY: string;
+  OPENAI_API_KEY?: string;
+  GOOGLE_API_KEY?: string;
 }


### PR DESCRIPTION
## Summary
- allow API key overrides via request header
- store API keys in local storage
- add UI to manage API keys in sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857ec89e494832eb9423aca5810fd35