### PR TITLE
Add multi-provider API support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for Bolt.new development
+# At least one provider key is required
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+
+# Optional logging level
+VITE_LOG_LEVEL=debug

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist-ssr
 
 /.cache
 /build
+!.env.example
 .env*
 *.vars
 .wrangler

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,13 @@ git clone https://github.com/stackblitz/bolt.new.git
 pnpm install
 ```
 
-3. Create a `.env.local` file in the root directory and add your Anthropic API key:
+3. Create a `.env.local` file in the root directory and add at least one API provider key:
 
 ```
+# one or more of these keys is required
 ANTHROPIC_API_KEY=XXX
+OPENAI_API_KEY=XXX
+GOOGLE_API_KEY=XXX
 ```
 
 Optionally, you can set the debug level:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,23 @@ Here are some tips to get the most out of Bolt.new:
 
 - **Scaffold the basics first, then add features**: Make sure the basic structure of your application is in place before diving into more advanced functionality. This helps Bolt understand the foundation of your project and ensure everything is wired up right before building out more advanced functionality.
 
-- **Batch simple instructions**: Save time by combining simple instructions into one message. For example, you can ask Bolt to change the color scheme, add mobile responsiveness, and restart the dev server, all in one go saving you time and reducing API credit consumption significantly.
+
+## Environment Variables
+
+Bolt requires at least one API provider key to run. Create a `.env.local` file in the project root and add your available keys:
+
+```
+# at least one key is required
+ANTHROPIC_API_KEY=XXX
+OPENAI_API_KEY=XXX
+GOOGLE_API_KEY=XXX
+```
+
+You can also set the optional logging level:
+
+```
+VITE_LOG_LEVEL=debug
+```
 
 ## FAQs
 

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -8,6 +8,7 @@ import { useMessageParser, usePromptEnhancer, useShortcuts, useSnapScroll } from
 import { useChatHistory } from '~/lib/persistence';
 import { chatStore } from '~/lib/stores/chat';
 import { workbenchStore } from '~/lib/stores/workbench';
+import { apiConfigStore } from '~/lib/stores/apiConfig';
 import { fileModificationsToHTML } from '~/utils/diff';
 import { cubicEasingFn } from '~/utils/easings';
 import { createScopedLogger, renderLogger } from '~/utils/logger';
@@ -75,8 +76,11 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
 
   const [animationScope, animate] = useAnimate();
 
+  const apiConfig = useStore(apiConfigStore);
+
   const { messages, isLoading, input, handleInputChange, setInput, stop, append } = useChat({
     api: '/api/chat',
+    headers: apiConfig ? { 'x-api-provider': apiConfig.provider, 'x-api-key': apiConfig.apiKey } : undefined,
     onError: (error) => {
       logger.error('Request failed\n\n', error);
       toast.error('There was an error processing your request');

--- a/app/components/header/ApiKeyDialog.client.tsx
+++ b/app/components/header/ApiKeyDialog.client.tsx
@@ -1,0 +1,82 @@
+import { useStore } from '@nanostores/react';
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from '~/components/ui/Dialog';
+import { apiConfigStore, setAPIConfig, type Provider } from '~/lib/stores/apiConfig';
+
+interface Props {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+}
+
+const providers: Provider[] = ['anthropic', 'openai', 'google'];
+
+export function ApiKeyDialog({ open, onOpenChange }: Props) {
+  const current = useStore(apiConfigStore);
+  const [provider, setProvider] = useState<Provider>(current?.provider ?? 'openai');
+  const [apiKey, setApiKey] = useState(current?.apiKey ?? '');
+  const [testResult, setTestResult] = useState<string>();
+
+  const testKey = async () => {
+    const res = await fetch('/api/test-key', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ provider, apiKey }),
+    });
+    const data = await res.json();
+
+    if (data.success) {
+      setTestResult('Success');
+    } else {
+      setTestResult('Failed');
+      toast.error('API key test failed');
+    }
+  };
+
+  const save = () => {
+    setAPIConfig({ provider, apiKey });
+    onOpenChange(false);
+  };
+
+  return (
+    <DialogRoot open={open}>
+      <Dialog onBackdrop={() => onOpenChange(false)} onClose={() => onOpenChange(false)}>
+        <DialogTitle>API Configuration</DialogTitle>
+        <DialogDescription>
+          <div className="flex flex-col gap-2">
+            <label className="flex gap-2 items-center">
+              Provider
+              <select
+                value={provider}
+                onChange={(e) => setProvider(e.target.value as Provider)}
+                className="flex-1 border p-1 rounded"
+              >
+                {providers.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex gap-2 items-center">
+              API Key
+              <input value={apiKey} onChange={(e) => setApiKey(e.target.value)} className="flex-1 border p-1 rounded" />
+            </label>
+            {testResult && <p>Test result: {testResult}</p>}
+          </div>
+        </DialogDescription>
+        <div className="px-5 pb-4 bg-bolt-elements-background-depth-2 flex gap-2 justify-end">
+          <DialogButton type="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </DialogButton>
+          <DialogButton type="primary" onClick={testKey}>
+            Test
+          </DialogButton>
+          <DialogButton type="primary" onClick={save}>
+            Save
+          </DialogButton>
+        </div>
+      </Dialog>
+    </DialogRoot>
+  );
+}

--- a/app/components/header/HeaderActionButtons.client.tsx
+++ b/app/components/header/HeaderActionButtons.client.tsx
@@ -1,13 +1,16 @@
 import { useStore } from '@nanostores/react';
+import { useState } from 'react';
 import { chatStore } from '~/lib/stores/chat';
 import { workbenchStore } from '~/lib/stores/workbench';
 import { classNames } from '~/utils/classNames';
+import { ApiKeyDialog } from './ApiKeyDialog.client';
 
 interface HeaderActionButtonsProps {}
 
 export function HeaderActionButtons({}: HeaderActionButtonsProps) {
   const showWorkbench = useStore(workbenchStore.showWorkbench);
   const { showChat } = useStore(chatStore);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   const canHideChat = showWorkbench || !showChat;
 
@@ -38,7 +41,12 @@ export function HeaderActionButtons({}: HeaderActionButtonsProps) {
         >
           <div className="i-ph:code-bold" />
         </Button>
+        <div className="w-[1px] bg-bolt-elements-borderColor" />
+        <Button onClick={() => setDialogOpen(true)}>
+          <div className="i-ph:key" />
+        </Button>
       </div>
+      <ApiKeyDialog open={dialogOpen} onOpenChange={setDialogOpen} />
     </div>
   );
 }

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -2,7 +2,6 @@ import { motion, type Variants } from 'framer-motion';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from '~/components/ui/Dialog';
-import { IconButton } from '~/components/ui/IconButton';
 import { ThemeSwitch } from '~/components/ui/ThemeSwitch';
 import { db, deleteById, getAll, chatId, type ChatHistoryItem } from '~/lib/persistence';
 import { cubicEasingFn } from '~/utils/easings';

--- a/app/lib/.server/llm/api-key.ts
+++ b/app/lib/.server/llm/api-key.ts
@@ -1,9 +1,33 @@
 import { env } from 'node:process';
+import type { Provider } from '~/lib/stores/apiConfig';
 
-export function getAPIKey(cloudflareEnv: Env) {
-  /**
-   * The `cloudflareEnv` is only used when deployed or when previewing locally.
-   * In development the environment variables are available through `env`.
-   */
-  return env.ANTHROPIC_API_KEY || cloudflareEnv.ANTHROPIC_API_KEY;
+export interface APIConfig {
+  provider: Provider;
+  apiKey: string;
+}
+
+export function getAPIConfig(cloudflareEnv: Env, override?: APIConfig): APIConfig {
+  if (override) {
+    return override;
+  }
+
+  const anthropic = env.ANTHROPIC_API_KEY || cloudflareEnv.ANTHROPIC_API_KEY;
+
+  if (anthropic) {
+    return { provider: 'anthropic', apiKey: anthropic };
+  }
+
+  const openai = env.OPENAI_API_KEY || cloudflareEnv.OPENAI_API_KEY;
+
+  if (openai) {
+    return { provider: 'openai', apiKey: openai };
+  }
+
+  const google = env.GOOGLE_API_KEY || cloudflareEnv.GOOGLE_API_KEY;
+
+  if (google) {
+    return { provider: 'google', apiKey: google };
+  }
+
+  throw new Error('No API key provided');
 }

--- a/app/lib/.server/llm/model.ts
+++ b/app/lib/.server/llm/model.ts
@@ -1,9 +1,24 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import type { Provider } from '~/lib/stores/apiConfig';
 
-export function getAnthropicModel(apiKey: string) {
-  const anthropic = createAnthropic({
-    apiKey,
-  });
-
-  return anthropic('claude-3-5-sonnet-20240620');
+export function getModel(provider: Provider, apiKey: string) {
+  switch (provider) {
+    case 'anthropic': {
+      const anthropic = createAnthropic({ apiKey });
+      return anthropic('claude-3-5-sonnet-20240620');
+    }
+    case 'openai': {
+      const openai = createOpenAI({ apiKey });
+      return openai('gpt-4o');
+    }
+    case 'google': {
+      const google = createGoogleGenerativeAI({ apiKey });
+      return google('gemini-1.5-pro-latest');
+    }
+    default: {
+      throw new Error('Unknown provider');
+    }
+  }
 }

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -1,6 +1,6 @@
 import { streamText as _streamText, convertToCoreMessages } from 'ai';
-import { getAPIKey } from '~/lib/.server/llm/api-key';
-import { getAnthropicModel } from '~/lib/.server/llm/model';
+import { getAPIConfig, type APIConfig } from '~/lib/.server/llm/api-key';
+import { getModel } from '~/lib/.server/llm/model';
 import { MAX_TOKENS } from './constants';
 import { getSystemPrompt } from './prompts';
 
@@ -21,14 +21,14 @@ export type Messages = Message[];
 
 export type StreamingOptions = Omit<Parameters<typeof _streamText>[0], 'model'>;
 
-export function streamText(messages: Messages, env: Env, options?: StreamingOptions) {
+export function streamText(messages: Messages, env: Env, options?: StreamingOptions, override?: APIConfig) {
+  const config = getAPIConfig(env, override);
+
   return _streamText({
-    model: getAnthropicModel(getAPIKey(env)),
+    model: getModel(config.provider, config.apiKey),
     system: getSystemPrompt(),
     maxTokens: MAX_TOKENS,
-    headers: {
-      'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15',
-    },
+    headers: config.provider === 'anthropic' ? { 'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15' } : undefined,
     messages: convertToCoreMessages(messages),
     ...options,
   });

--- a/app/lib/stores/apiConfig.ts
+++ b/app/lib/stores/apiConfig.ts
@@ -1,0 +1,30 @@
+import { atom } from 'nanostores';
+
+export type Provider = 'anthropic' | 'openai' | 'google';
+
+export interface APIConfig {
+  provider: Provider;
+  apiKey: string;
+}
+
+const STORAGE_KEY = 'bolt_api_config';
+
+export const apiConfigStore = atom<APIConfig | null>(initStore());
+
+function initStore(): APIConfig | null {
+  if (import.meta.env.SSR) {
+    return null;
+  }
+
+  const data = localStorage.getItem(STORAGE_KEY);
+
+  return data ? (JSON.parse(data) as APIConfig) : null;
+}
+
+export function setAPIConfig(config: APIConfig) {
+  apiConfigStore.set(config);
+
+  if (!import.meta.env.SSR) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+  }
+}

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -3,6 +3,7 @@ import { MAX_RESPONSE_SEGMENTS, MAX_TOKENS } from '~/lib/.server/llm/constants';
 import { CONTINUE_PROMPT } from '~/lib/.server/llm/prompts';
 import { streamText, type Messages, type StreamingOptions } from '~/lib/.server/llm/stream-text';
 import SwitchableStream from '~/lib/.server/llm/switchable-stream';
+import type { Provider } from '~/lib/stores/apiConfig';
 
 export async function action(args: ActionFunctionArgs) {
   return chatAction(args);
@@ -10,6 +11,10 @@ export async function action(args: ActionFunctionArgs) {
 
 async function chatAction({ context, request }: ActionFunctionArgs) {
   const { messages } = await request.json<{ messages: Messages }>();
+
+  const provider = request.headers.get('x-api-provider') as Provider | null;
+  const apiKey = request.headers.get('x-api-key');
+  const override = provider && apiKey ? { provider, apiKey } : undefined;
 
   const stream = new SwitchableStream();
 
@@ -32,13 +37,13 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
         messages.push({ role: 'assistant', content });
         messages.push({ role: 'user', content: CONTINUE_PROMPT });
 
-        const result = await streamText(messages, context.cloudflare.env, options);
+        const result = await streamText(messages, context.cloudflare.env, options, override);
 
         return stream.switchSource(result.toAIStream());
       },
     };
 
-    const result = await streamText(messages, context.cloudflare.env, options);
+    const result = await streamText(messages, context.cloudflare.env, options, override);
 
     stream.switchSource(result.toAIStream());
 

--- a/app/routes/api.test-key.ts
+++ b/app/routes/api.test-key.ts
@@ -1,0 +1,31 @@
+import { type ActionFunctionArgs } from '@remix-run/cloudflare';
+import { generateText } from 'ai';
+import { getAPIConfig, type APIConfig } from '~/lib/.server/llm/api-key';
+import { getModel } from '~/lib/.server/llm/model';
+
+export async function action(args: ActionFunctionArgs) {
+  return testAction(args);
+}
+
+async function testAction({ context, request }: ActionFunctionArgs) {
+  const { provider, apiKey } = await request.json<APIConfig>();
+
+  try {
+    const config = provider && apiKey ? { provider, apiKey } : getAPIConfig(context.cloudflare.env);
+
+    await generateText({
+      model: getModel(config.provider, config.apiKey),
+      messages: [{ role: 'user', content: 'Hello' }],
+      maxTokens: 1,
+    });
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'content-type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ success: false, message: String(error) }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^0.0.39",
+    "@ai-sdk/google": "^1.2.19",
+    "@ai-sdk/openai": "^1.3.22",
     "@codemirror/autocomplete": "^6.17.0",
     "@codemirror/commands": "^6.6.0",
     "@codemirror/lang-cpp": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^0.0.39
         version: 0.0.39(zod@3.23.8)
+      '@ai-sdk/google':
+        specifier: ^1.2.19
+        version: 1.2.19(zod@3.23.8)
+      '@ai-sdk/openai':
+        specifier: ^1.3.22
+        version: 1.3.22(zod@3.23.8)
       '@codemirror/autocomplete':
         specifier: ^6.17.0
         version: 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.4)(@lezer/common@1.2.1)
@@ -237,6 +243,18 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@ai-sdk/google@1.2.19':
+    resolution: {integrity: sha512-Xgl6eftIRQ4srUdCzxM112JuewVMij5q4JLcNmHcB68Bxn9dpr3MVUSPlJwmameuiQuISIA8lMB+iRiRbFsaqA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/openai@1.3.22':
+    resolution: {integrity: sha512-QwA+2EkG0QyjVR+7h6FE7iOu2ivNqAVMm9UJZkVxxTk5OIq5fFJDTEI/zICEMuHImTTXR2JjsL6EirJ28Jc4cw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
   '@ai-sdk/provider-utils@1.0.9':
     resolution: {integrity: sha512-yfdanjUiCJbtGoRGXrcrmXn0pTyDfRIeY6ozDG96D66f2wupZaZvAgKptUa3zDYXtUCQQvcNJ+tipBBfQD/UYA==}
     engines: {node: '>=18'}
@@ -246,8 +264,18 @@ packages:
       zod:
         optional: true
 
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
   '@ai-sdk/provider@0.0.17':
     resolution: {integrity: sha512-f9j+P5yYRkqKFHxvWae5FI0j6nqROPCoPnMkpc2hc2vC7vKjqzrxBJucD8rpSaUjqiBnY/QuRJ0QeV717Uz5tg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@0.0.40':
@@ -3789,6 +3817,11 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -5202,6 +5235,18 @@ snapshots:
       '@ai-sdk/provider-utils': 1.0.9(zod@3.23.8)
       zod: 3.23.8
 
+  '@ai-sdk/google@1.2.19(zod@3.23.8)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.23.8)
+      zod: 3.23.8
+
+  '@ai-sdk/openai@1.3.22(zod@3.23.8)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.23.8)
+      zod: 3.23.8
+
   '@ai-sdk/provider-utils@1.0.9(zod@3.23.8)':
     dependencies:
       '@ai-sdk/provider': 0.0.17
@@ -5211,7 +5256,18 @@ snapshots:
     optionalDependencies:
       zod: 3.23.8
 
+  '@ai-sdk/provider-utils@2.2.8(zod@3.23.8)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.23.8
+
   '@ai-sdk/provider@0.0.17':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -9518,6 +9574,8 @@ snapshots:
   ms@2.1.3: {}
 
   mustache@4.2.0: {}
+
+  nanoid@3.3.11: {}
 
   nanoid@3.3.6: {}
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1,3 +1,5 @@
 interface Env {
-  ANTHROPIC_API_KEY: string;
+  ANTHROPIC_API_KEY?: string;
+  OPENAI_API_KEY?: string;
+  GOOGLE_API_KEY?: string;
 }


### PR DESCRIPTION
## Summary
- allow selecting Anthropic, OpenAI or Google Generative AI
- persist API keys in local storage
- add UI dialog to manage API keys
- send API key from client to server for chat requests
- include API key test endpoint
- show toast on failed API-key test
- document new environment variables and provide `.env.example`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a372b0720832ea54029f798b173f3