### PR TITLE
Fix API Keys dialog not shown on landing page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,7 @@ ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 GOOGLE_API_KEY=
 
+# You can also add or update keys from the UI via the "API Keys" button.
+
 # Optional logging level
 VITE_LOG_LEVEL=debug

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You can also set the optional logging level:
 VITE_LOG_LEVEL=debug
 ```
 
+After starting the development server, open the site and click the **🔑 API Keys** button in the header to enter your keys.
+
 ## FAQs
 
 **Where do I sign up for a paid plan?**  

--- a/app/components/header/Header.tsx
+++ b/app/components/header/Header.tsx
@@ -27,15 +27,13 @@ export function Header() {
       <span className="flex-1 px-4 truncate text-center text-bolt-elements-textPrimary">
         <ClientOnly>{() => <ChatDescription />}</ClientOnly>
       </span>
-      {chat.started && (
-        <ClientOnly>
-          {() => (
-            <div className="mr-1">
-              <HeaderActionButtons />
-            </div>
-          )}
-        </ClientOnly>
-      )}
+      <ClientOnly>
+        {() => (
+          <div className="mr-1">
+            <HeaderActionButtons />
+          </div>
+        )}
+      </ClientOnly>
     </header>
   );
 }

--- a/app/components/header/HeaderActionButtons.client.tsx
+++ b/app/components/header/HeaderActionButtons.client.tsx
@@ -44,6 +44,7 @@ export function HeaderActionButtons({}: HeaderActionButtonsProps) {
         <div className="w-[1px] bg-bolt-elements-borderColor" />
         <Button onClick={() => setDialogOpen(true)}>
           <div className="i-ph:key" />
+          <span>API Keys</span>
         </Button>
       </div>
       <ApiKeyDialog open={dialogOpen} onOpenChange={setDialogOpen} />
@@ -61,7 +62,7 @@ interface ButtonProps {
 function Button({ active = false, disabled = false, children, onClick }: ButtonProps) {
   return (
     <button
-      className={classNames('flex items-center p-1.5', {
+      className={classNames('flex items-center gap-1 p-1.5', {
         'bg-bolt-elements-item-backgroundDefault hover:bg-bolt-elements-item-backgroundActive text-bolt-elements-textTertiary hover:text-bolt-elements-textPrimary':
           !active,
         'bg-bolt-elements-item-backgroundAccent text-bolt-elements-item-contentAccent': active && !disabled,

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "devDependencies": {
     "@blitz/eslint-plugin": "0.1.0",
     "@cloudflare/workers-types": "^4.20240620.0",
+    "@playwright/test": "^1.44.0",
     "@remix-run/dev": "^2.10.0",
     "@types/diff": "^5.2.1",
     "@types/react": "^18.2.20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'pnpm dev',
+    port: 5173,
+    reuseExistingServer: true,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20240620.0
         version: 4.20240620.0
+      '@playwright/test':
+        specifier: ^1.44.0
+        version: 1.53.1
       '@remix-run/dev':
         specifier: ^2.10.0
         version: 2.10.0(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2))(@remix-run/serve@2.10.0(typescript@5.5.2))(@types/node@20.14.9)(sass@1.77.6)(typescript@5.5.2)(vite@5.3.1(@types/node@20.14.9)(sass@1.77.6))(wrangler@3.63.2(@cloudflare/workers-types@4.20240620.0))
@@ -1190,6 +1193,11 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.53.1':
+    resolution: {integrity: sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.25':
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
@@ -2906,6 +2914,11 @@ packages:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4066,6 +4079,16 @@ packages:
 
   pkg-types@1.1.1:
     resolution: {integrity: sha512-ko14TjmDuQJ14zsotODv7dBlwxKhUKQEhuhmbqo1uCi9BB0Z2alo/wAXg6q1dTR5TyuqYyWhjtfe/Tsh+X28jQ==}
+
+  playwright-core@1.53.1:
+    resolution: {integrity: sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.53.1:
+    resolution: {integrity: sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -6191,6 +6214,10 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
+  '@playwright/test@1.53.1':
+    dependencies:
+      playwright: 1.53.1
+
   '@polka/url@1.0.0-next.25': {}
 
   '@radix-ui/primitive@1.1.0': {}
@@ -8260,6 +8287,9 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9851,6 +9881,14 @@ snapshots:
       confbox: 0.1.7
       mlly: 1.7.1
       pathe: 1.1.2
+
+  playwright-core@1.53.1: {}
+
+  playwright@1.53.1:
+    dependencies:
+      playwright-core: 1.53.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.0.0: {}
 

--- a/tests/api-key.e2e.ts
+++ b/tests/api-key.e2e.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('API key button opens dialog', async ({ page }) => {
+  await page.goto('/');
+
+  const button = page.getByRole('button', { name: /API Keys/i });
+  await expect(button).toBeVisible();
+  await button.click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByLabel('Provider')).toBeVisible();
+  await expect(dialog.getByLabel('API Key')).toBeVisible();
+  await expect(dialog.getByRole('button', { name: /Test/i })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- always render HeaderActionButtons so API key UI is available on all pages
- show an "API Keys" label next to the key icon
- tweak HeaderActionButtons button spacing
- document how to open the API key dialog
- hint about UI API key entry in `.env.example`
- add Playwright test and configuration

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a452a4430832eb234dcc0e6da51ef