### PR TITLE
Fix: ignore response-metadata chunks in stream-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ VITE_LOG_LEVEL=debug
 
 After starting the development server, open the site and click the **🔑 API Keys** button in the header to enter your keys.
 
+### Troubleshooting
+
+If you see an "Unhandled chunk type: response-metadata" error when chatting,
+update your dependencies and restart the dev server. This repository now filters
+those chunks so the chat endpoint streams normally.
+
 ## FAQs
 
 **Where do I sign up for a paid plan?**  

--- a/app/lib/.server/llm/stream-text.spec.ts
+++ b/app/lib/.server/llm/stream-text.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// mock the ai package used by stream-text.ts
+const fakeChunks = [
+  { type: 'response-metadata', foo: 'bar' },
+  { type: 'text-delta', textDelta: 'hi' },
+  {
+    type: 'finish',
+    finishReason: 'stop',
+    usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+  },
+];
+
+const fakeStream = new ReadableStream({
+  start(controller) {
+    for (const chunk of fakeChunks) {
+      controller.enqueue(chunk);
+    }
+    controller.close();
+  },
+});
+
+const fakeResult = { originalStream: fakeStream } as any;
+
+vi.mock('ai', async () => {
+  return {
+    streamText: vi.fn(() => fakeResult),
+    convertToCoreMessages: (m: any) => m,
+  };
+});
+
+import { streamText } from './stream-text';
+
+describe('streamText', () => {
+  it('ignores response-metadata chunks', async () => {
+    const env = { OPENAI_API_KEY: 'test-key' } as Env;
+    const result = streamText([], env);
+    const reader = (result as any).originalStream.getReader();
+    const received: any[] = [];
+
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        break;
+      }
+
+      received.push(value);
+    }
+
+    expect(received).not.toContainEqual(expect.objectContaining({ type: 'response-metadata' }));
+    expect(received).toContainEqual(expect.objectContaining({ type: 'text-delta', textDelta: 'hi' }));
+  });
+});

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -24,7 +24,7 @@ export type StreamingOptions = Omit<Parameters<typeof _streamText>[0], 'model'>;
 export function streamText(messages: Messages, env: Env, options?: StreamingOptions, override?: APIConfig) {
   const config = getAPIConfig(env, override);
 
-  return _streamText({
+  const result = _streamText({
     model: getModel(config.provider, config.apiKey),
     system: getSystemPrompt(),
     maxTokens: MAX_TOKENS,
@@ -32,4 +32,21 @@ export function streamText(messages: Messages, env: Env, options?: StreamingOpti
     messages: convertToCoreMessages(messages),
     ...options,
   });
+
+  // filter out `response-metadata` chunks emitted by newer LLM streams
+  if ((result as any).originalStream instanceof ReadableStream) {
+    (result as any).originalStream = (result as any).originalStream.pipeThrough(
+      new TransformStream({
+        transform(chunk, controller) {
+          if (chunk && (chunk as any).type === 'response-metadata') {
+            return;
+          }
+
+          controller.enqueue(chunk);
+        },
+      }),
+    );
+  }
+
+  return result;
 }

--- a/tests/chat.e2e.ts
+++ b/tests/chat.e2e.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+// simulate a streaming response including a response-metadata chunk
+const streamBody = [
+  'data: {"type":"response-metadata"}\n\n',
+  'data: {"type":"text-delta","textDelta":"Hello"}\n\n',
+  'data: {"type":"finish","finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n\n',
+].join('');
+
+test('chat streams without vite overlay', async ({ page }) => {
+  await page.route('/api/chat', (route) => {
+    route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+      body: streamBody,
+    });
+  });
+
+  await page.goto('/');
+
+  const textarea = page.getByPlaceholder('How can Bolt help you today?');
+  await textarea.fill('hello');
+  await textarea.press('Enter');
+
+  // wait for streaming to finish
+  await page.waitForTimeout(500);
+
+  const overlay = page.locator('#vite-error-overlay');
+  await expect(overlay).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- ignore `response-metadata` chunks in `stream-text`
- add regression unit test
- add e2e test for streaming
- document troubleshooting step about the new chunk type

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a4a0c4ca0832ebf989c95f0398093